### PR TITLE
Fix: safe XML parsing to prevent ParseError on invalid UPnP metadata

### DIFF
--- a/custom_components/yamaha_soundbar/media_player.py
+++ b/custom_components/yamaha_soundbar/media_player.py
@@ -28,6 +28,8 @@ from async_upnp_client.client_factory import UpnpFactory
 from async_upnp_client.aiohttp import AiohttpRequester
 import xml.etree.ElementTree as ET
 
+
+from xml.etree.ElementTree import ParseError
 import re
 import struct
 import chardet
@@ -2678,7 +2680,12 @@ class YamahaDevice(MediaPlayerEntity):
         except:
             _LOGGER.warning("GetMediaInfo/CurrentURIMetaData UPNP error: %s", self.entity_id)
 
-        if media_metadata is None:
+        if not media_metadata or not isinstance(media_metadata, str):
+            _LOGGER.debug("UPnP: media_metadata assente/non stringa per %s", self.entity_id)
+            return
+
+        if not media_metadata.strip().startswith("<"):
+            _LOGGER.debug("UPnP: media_metadata non sembra XML per %s: %r", self.entity_id, media_metadata[:120])
             return
 
         self._media_title = None
@@ -2686,7 +2693,11 @@ class YamahaDevice(MediaPlayerEntity):
         self._media_artist = None
         self._media_image_url = None
 
-        xml_tree = ET.fromstring(media_metadata)
+        try:
+            xml_tree = ET.fromstring(media_metadata)
+        except ParseError as exc:
+            _LOGGER.debug("UPnP: XML malformato in media_metadata per %s: %s", self.entity_id, exc)
+            return
 
         xml_path = "{urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/}item/"
         title_xml_path = "{http://purl.org/dc/elements/1.1/}title"
@@ -2702,15 +2713,22 @@ class YamahaDevice(MediaPlayerEntity):
                 self._media_artist = string.capwords(titles[0].strip())
                 self._media_title = string.capwords(titles[1].strip())
             else:
-                self._media_title = string.capwords(title.strip())
+                self._media_title = string.capwords(title.strip()) if title else None
         else:
-            self._media_title = xml_tree.find("{0}{1}".format(xml_path, title_xml_path)).text
-            self._media_artist = xml_tree.find("{0}{1}".format(xml_path, artist_xml_path)).text
-            self._media_album = xml_tree.find("{0}{1}".format(xml_path, album_xml_path)).text
+            t_el = xml_tree.find(f"{xml_path}{title_xml_path}")
+            self._media_title = t_el.text if t_el is not None else None
+            a_el = xml_tree.find(f"{xml_path}{artist_xml_path}")
+            self._media_artist = a_el.text if a_el is not None else None
+            al_el = xml_tree.find(f"{xml_path}{album_xml_path}")
+            self._media_album = al_el.text if al_el is not None else None
 
-        self._media_image_url = xml_tree.find("{0}{1}".format(xml_path, image_xml_path)).text
+        img_el = xml_tree.find(f"{xml_path}{image_xml_path}")
+        self._media_image_url = img_el.text if img_el is not None else None
 
-        if not validators.url(self._media_image_url):
+        try:
+            if not self._media_image_url or not validators.url(self._media_image_url):
+                self._media_image_url = None
+        except Exception:
             self._media_image_url = None
 
     async def async_tracklist_via_upnp(self, media):
@@ -2738,10 +2756,19 @@ class YamahaDevice(MediaPlayerEntity):
         except:
             _LOGGER.debug("PlayQueue/QueueContext UPNP error, media not present?: %s", self.entity_id)
 
-        if media_metadata is None:
+        if not media_metadata or not isinstance(media_metadata, str):
+            _LOGGER.debug("UPnP: media_metadata assente/non stringa per %s", self.entity_id)
             return
 
-        xml_tree = ET.fromstring(media_metadata)
+        if not media_metadata.strip().startswith("<"):
+            _LOGGER.debug("UPnP: media_metadata non sembra XML per %s: %r", self.entity_id, media_metadata[:120])
+            return
+
+        try:
+            xml_tree = ET.fromstring(media_metadata)
+        except ParseError as exc:
+            _LOGGER.debug("UPnP: XML malformato in media_metadata per %s: %s", self.entity_id, exc)
+            return
 
         trackq = []
         for playlist in xml_tree:
@@ -2782,7 +2809,14 @@ class YamahaDevice(MediaPlayerEntity):
             _LOGGER.debug("GetKeyMapping UPNP error: %s", self.entity_id)
             return
 
-        xml_tree = ET.fromstring(preset_map)
+        if not preset_map or not isinstance(preset_map, str) or not preset_map.strip().startswith("<"):
+            _LOGGER.error("Preset Map non valido per %s: %r", self.entity_id, str(preset_map)[:120])
+            return
+        try:
+            xml_tree = ET.fromstring(preset_map)
+        except ParseError as exc:
+            _LOGGER.error("Preset Map XML malformato per %s: %s", self.entity_id, exc)
+            return
 
         if xml_tree.find('Key'+presetnum) is None:
             _LOGGER.error("Preset Map error: %s num: %s. Please create a Spotify preset first with the mobile app for this player. Tree: %s", self.entity_id, presetnum, preset_map)


### PR DESCRIPTION
# Fix: Safe XML parsing to prevent `ParseError` when UPnP metadata is invalid

Hello,  
I’m using a Yamaha YAS-109 with the `yamaha_soundbar` custom component.  
Sometimes, when updating via UPnP (`async_update_via_upnp`), the device returns `CurrentURIMetaData` that is empty, non-XML, or malformed (often when switching sources or when the network is slow).

In the current code, `ET.fromstring(...)` is called without validation, which raises an `xml.etree.ElementTree.ParseError` and stops the entity update.  
The same issue can occur in:
- `async_update_via_upnp` (`CurrentURIMetaData`)
- `async_tracklist_via_upnp` (`QueueContext`)
- `async_preset_snap_via_upnp` (`preset_map`)

---

**Example error:**
```
xml.etree.ElementTree.ParseError: not well-formed (invalid token): line 18, column 28
```

---

## Suggested fix
- Validate that the string is non-empty, is a `str`, and starts with `<`.
- Wrap `ET.fromstring(...)` in a `try/except ParseError` block.
- Fallback gracefully (skip update) instead of raising, while logging in DEBUG for diagnosis.
- Also, protect `validators.url(...)` with a try/except to avoid unrelated exceptions.

---

## Patch (diff)
```diff
*** a/custom_components/yamaha_soundbar/media_player.py
--- b/custom_components/yamaha_soundbar/media_player.py
@@
 import xml.etree.ElementTree as ET
+from xml.etree.ElementTree import ParseError
@@ def async_update_via_upnp(self):
-        if media_metadata is None:
-            return
-
-        self._media_title = None
-        self._media_album = None
-        self._media_artist = None
-        self._media_image_url = None
-
-        xml_tree = ET.fromstring(media_metadata)
+        if not media_metadata or not isinstance(media_metadata, str):
+            _LOGGER.debug("UPnP: media_metadata assente/non stringa per %s", self.entity_id)
+            return
+        if not media_metadata.strip().startswith("<"):
+            _LOGGER.debug("UPnP: media_metadata non sembra XML per %s: %r", self.entity_id, media_metadata[:120])
+            return
+
+        self._media_title = None
+        self._media_album = None
+        self._media_artist = None
+        self._media_image_url = None
+
+        try:
+            xml_tree = ET.fromstring(media_metadata)
+        except ParseError as exc:
+            _LOGGER.debug("UPnP: XML malformato in media_metadata per %s: %s", self.entity_id, exc)
+            return
@@
-        if radio:
-            title = xml_tree.find("{0}{1}".format(xml_path, radiosub_xml_path)).text
+        if radio:
+            title_el = xml_tree.find(f"{xml_path}{radiosub_xml_path}")
+            title = title_el.text if title_el is not None else None
             if title.find(' - ') != -1:
                 titles = title.split(' - ')
                 self._media_artist = string.capwords(titles[0].strip())
                 self._media_title = string.capwords(titles[1].strip())
             else:
-                self._media_title = string.capwords(title.strip())
+                self._media_title = string.capwords(title.strip()) if title else None
         else:
-            self._media_title = xml_tree.find("{0}{1}".format(xml_path, title_xml_path)).text
-            self._media_artist = xml_tree.find("{0}{1}".format(xml_path, artist_xml_path)).text
-            self._media_album = xml_tree.find("{0}{1}".format(xml_path, album_xml_path)).text
+            t_el = xml_tree.find(f"{xml_path}{title_xml_path}")
+            a_el = xml_tree.find(f"{xml_path}{artist_xml_path}")
+            al_el = xml_tree.find(f"{xml_path}{album_xml_path}")
+            self._media_title = t_el.text if t_el is not None else None
+            self._media_artist = a_el.text if a_el is not None else None
+            self._media_album = al_el.text if al_el is not None else None
@@
-        self._media_image_url = xml_tree.find("{0}{1}".format(xml_path, image_xml_path)).text
-
-        if not validators.url(self._media_image_url):
-            self._media_image_url = None
+        img_el = xml_tree.find(f"{xml_path}{image_xml_path}")
+        self._media_image_url = img_el.text if img_el is not None else None
+
+        try:
+            if not self._media_image_url or not validators.url(self._media_image_url):
+                self._media_image_url = None
+        except Exception:
+            self._media_image_url = None
@@ def async_tracklist_via_upnp(self, media):
-        if media_metadata is None:
-            return
-
-        xml_tree = ET.fromstring(media_metadata)
+        if not media_metadata or not isinstance(media_metadata, str) or not media_metadata.strip().startswith("<"):
+            _LOGGER.debug("UPnP: QueueContext non valido per %s", self.entity_id)
+            return
+        try:
+            xml_tree = ET.fromstring(media_metadata)
+        except ParseError as exc:
+            _LOGGER.debug("UPnP: XML malformato in QueueContext per %s: %s", self.entity_id, exc)
+            return
@@ def async_preset_snap_via_upnp(self, presetnum):
-        xml_tree = ET.fromstring(preset_map)
+        if not preset_map or not isinstance(preset_map, str) or not preset_map.strip().startswith("<"):
+            _LOGGER.error("Preset Map non valido per %s: %r", self.entity_id, str(preset_map)[:120])
+            return
+        try:
+            xml_tree = ET.fromstring(preset_map)
+        except ParseError as exc:
+            _LOGGER.error("Preset Map XML malformato per %s: %s", self.entity_id, exc)
+            return
```

---

## Benefits
- Prevents recurring `ParseError` spam in logs.
- Keeps the entity updating even when metadata is invalid.
- Improves robustness against network hiccups or malformed UPnP responses.

Thanks for your work on this integration!  
Happy to open a PR if you prefer.
